### PR TITLE
Improved error handling, run delete/find tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,7 +31,7 @@ jobs:
           - host: windows-latest
             build: |
               yarn build --target i686-pc-windows-msvc
-              yarn test
+              yarn test && yarn test:find && yarn test:delete
             target: i686-pc-windows-msvc
           - host: ubuntu-latest
             target: x86_64-unknown-linux-gnu
@@ -182,7 +182,7 @@ jobs:
             yarn install
             yarn build
             strip -x *.node
-            yarn test
+            yarn test && yarn test:find && yarn test:delete
             rm -rf node_modules
             rm -rf target
       - name: Upload artifact
@@ -230,7 +230,7 @@ jobs:
         run: ls -R .
         shell: bash
       - name: Test bindings
-        run: yarn test
+        run: yarn test && yarn test:find && yarn test:delete
   test-linux-x64-gnu-binding:
     name: Test bindings on Linux-x64-gnu - node@${{ matrix.node }}
     needs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -868,18 +868,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -914,6 +914,7 @@ dependencies = [
  "napi-derive",
  "secret-service",
  "security-framework",
+ "thiserror",
  "windows",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ cfg-if = "1.0"
 # Default enable napi4 feature, see https://nodejs.org/api/n-api.html#node-api-version-matrix
 napi = {version = "2.10.1", default-features = false, features = ["napi4"]}
 napi-derive = "2.9.1"
+thiserror = "1.0.38"
 
 [target.'cfg(target_os = "windows")'.dependencies.windows]
 features = [

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Some benefits to using keytar-rs:
 
 - [x] **Cross-platform support** makes for straight-forward secrets management
 - [x] **Existing OS credentials are supported** out-of-the-box
-- [x] **Avoids heap allocation** - memory allocation only performed as needed within OS-specific APIs
+- [x] **Avoids memory allocation** - memory only allocated as needed for OS-specific APIs
 
 ## Node API usage
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
     "build:debug": "napi build --platform",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "ava",
+    "test:delete": "ava --match=\"delete*\"",
+    "test:find": "ava --match=\"find*\"",
     "version": "napi version"
   },
   "packageManager": "yarn@3.3.0"

--- a/src/keytar/error.rs
+++ b/src/keytar/error.rs
@@ -1,5 +1,5 @@
 pub struct Error {
-  pub code: Option<u32>,
+  pub code: Option<i32>,
   pub details: Option<String>,
 }
 

--- a/src/keytar/error.rs
+++ b/src/keytar/error.rs
@@ -1,9 +1,20 @@
+use std::string::FromUtf8Error;
+
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum KeytarError {
+  #[error("[keytar-rs] {service:?} library returned an error:\n\n{details:?}")]
+  Library { service: String, details: String },
+
+  #[error("[keytar-rs] No items were found that match the given parameters.")]
+  NotFound,
+
   #[error("[keytar-rs] An OS error has occurred:\n\n{0}")]
-  OSError(String),
+  Os(String),
+
+  #[error("[keytar-rs] A UTF-8 error has occurred:\n\n{0}")]
+  Utf8(String),
 }
 
 // TODO: remove and use enum above instead
@@ -35,5 +46,11 @@ impl ToString for Error {
         None => format!("[ERR] keytar-rs error - no further info provided."),
       },
     }
+  }
+}
+
+impl From<FromUtf8Error> for KeytarError {
+  fn from(error: FromUtf8Error) -> Self {
+    KeytarError::Utf8(format!("{:?}", error))
   }
 }

--- a/src/keytar/error.rs
+++ b/src/keytar/error.rs
@@ -1,3 +1,12 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum KeytarError {
+  #[error("[keytar-rs] An OS error has occurred:\n\n{0}")]
+  OSError(String),
+}
+
+// TODO: remove and use enum above instead
 pub struct Error {
   pub code: Option<i32>,
   pub details: Option<String>,

--- a/src/keytar/error.rs
+++ b/src/keytar/error.rs
@@ -1,11 +1,13 @@
 use std::{str::Utf8Error, string::FromUtf16Error, string::FromUtf8Error};
-
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum KeytarError {
-  #[error("[keytar-rs] {service:?} library returned an error:\n\n{details:?}")]
-  Library { service: String, details: String },
+  #[error("[keytar-rs] Invalid parameter provided for '{argument:?}'. Details:\n\n{details:?}")]
+  InvalidArg { argument: String, details: String },
+
+  #[error("[keytar-rs] {name:?} library returned an error:\n\n{details:?}")]
+  Library { name: String, details: String },
 
   #[error("[keytar-rs] No items were found that match the given parameters.")]
   NotFound,
@@ -18,38 +20,6 @@ pub enum KeytarError {
 
   #[error("[keytar-rs] A UTF-16 error has occurred:\n\n{0}")]
   Utf16(String),
-}
-
-// TODO: remove and use enum above instead
-pub struct Error {
-  pub code: Option<i32>,
-  pub details: Option<String>,
-}
-
-impl Error {
-  // not actually dead: only used on certain platforms
-  #[allow(dead_code)]
-  pub fn from_details(details: &str) -> Self {
-    Error {
-      code: None,
-      details: Some(details.to_string()),
-    }
-  }
-}
-
-impl ToString for Error {
-  fn to_string(&self) -> String {
-    match self.code {
-      Some(code) => match &self.details {
-        Some(detail) => format!("[ERR] keytar-rs - code: {}, details: {}", code, detail),
-        None => format!("[ERR] keytar-rs - code: {}", code),
-      },
-      None => match &self.details {
-        Some(detail) => format!("[ERR] keytar-rs - details: {}", detail),
-        None => format!("[ERR] keytar-rs error - no further info provided."),
-      },
-    }
-  }
 }
 
 impl From<FromUtf8Error> for KeytarError {

--- a/src/keytar/error.rs
+++ b/src/keytar/error.rs
@@ -1,4 +1,4 @@
-use std::string::FromUtf8Error;
+use std::{str::Utf8Error, string::FromUtf16Error, string::FromUtf8Error};
 
 use thiserror::Error;
 
@@ -15,6 +15,9 @@ pub enum KeytarError {
 
   #[error("[keytar-rs] A UTF-8 error has occurred:\n\n{0}")]
   Utf8(String),
+
+  #[error("[keytar-rs] A UTF-16 error has occurred:\n\n{0}")]
+  Utf16(String),
 }
 
 // TODO: remove and use enum above instead
@@ -51,6 +54,18 @@ impl ToString for Error {
 
 impl From<FromUtf8Error> for KeytarError {
   fn from(error: FromUtf8Error) -> Self {
+    KeytarError::Utf8(format!("{:?}", error))
+  }
+}
+
+impl From<FromUtf16Error> for KeytarError {
+  fn from(error: FromUtf16Error) -> Self {
+    KeytarError::Utf16(format!("{:?}", error))
+  }
+}
+
+impl From<Utf8Error> for KeytarError {
+  fn from(error: Utf8Error) -> Self {
     KeytarError::Utf8(format!("{:?}", error))
   }
 }

--- a/src/keytar/mac.rs
+++ b/src/keytar/mac.rs
@@ -9,7 +9,7 @@ use security_framework::{
 impl From<security_framework::base::Error> for Error {
   fn from(error: security_framework::base::Error) -> Self {
     Error {
-      code: error.code(),
+      code: Some(error.code()),
       details: error.message(),
     }
   }

--- a/src/keytar/mac.rs
+++ b/src/keytar/mac.rs
@@ -1,25 +1,17 @@
 extern crate security_framework;
-use crate::keytar::error::Error;
+use super::error::KeytarError;
+
 use security_framework::{
   item::{ItemClass, ItemSearchOptions, Limit},
   os::macos::passwords::find_generic_password,
   passwords::{delete_generic_password, get_generic_password, set_generic_password},
 };
 
-impl From<security_framework::base::Error> for Error {
+impl From<security_framework::base::Error> for KeytarError {
   fn from(error: security_framework::base::Error) -> Self {
-    Error {
-      code: Some(error.code()),
-      details: error.message(),
-    }
-  }
-}
-
-impl From<std::string::FromUtf8Error> for Error {
-  fn from(error: std::string::FromUtf8Error) -> Self {
-    Error {
-      code: None,
-      details: Some(error.to_string()),
+    KeytarError::Library {
+      name: "security_framework".to_string(),
+      details: format!("{:?}", error),
     }
   }
 }
@@ -28,26 +20,27 @@ pub fn set_password(
   service: &String,
   account: &String,
   password: &mut String,
-) -> Result<bool, Error> {
+) -> Result<bool, KeytarError> {
   match set_generic_password(service.as_str(), account.as_str(), password.as_bytes()) {
     Ok(()) => Ok(true),
-    Err(err) => Err(Error::from(err)),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
-pub fn get_password(service: &String, account: &String) -> Result<String, Error> {
+pub fn get_password(service: &String, account: &String) -> Result<String, KeytarError> {
   match get_generic_password(service.as_str(), account.as_str()) {
-    Ok(bytes) => Ok(String::from_utf8(bytes).unwrap()),
-    Err(err) => Err(Error::from(err)),
+    Ok(bytes) => Ok(String::from_utf8(bytes)?),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
-pub fn find_password(service: &String) -> Result<String, Error> {
+pub fn find_password(service: &String) -> Result<String, KeytarError> {
   let cred_attrs: Vec<&str> = service.split("/").collect();
   if cred_attrs.len() < 2 {
-    return Err(Error::from_details(
-      "Improper service string syntax for find_password",
-    ));
+    return Err(KeytarError::InvalidArg {
+      argument: "service".to_string(),
+      details: "Invalid format for service string; must be in format 'SERVICE/ACCOUNT'".to_string(),
+    });
   }
 
   match find_generic_password(None, cred_attrs[0], cred_attrs[1]) {
@@ -55,21 +48,21 @@ pub fn find_password(service: &String) -> Result<String, Error> {
       let pw_str = String::from_utf8(pw.to_owned())?;
       return Ok(pw_str);
     }
-    Err(err) => Err(Error::from(err)),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
-pub fn delete_password(service: &String, account: &String) -> Result<bool, Error> {
+pub fn delete_password(service: &String, account: &String) -> Result<bool, KeytarError> {
   match delete_generic_password(service.as_str(), account.as_str()) {
     Ok(_) => Ok(true),
-    Err(err) => Err(Error::from(err)),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
 pub fn find_credentials(
   service: &String,
   credentials: &mut Vec<(String, String)>,
-) -> Result<bool, Error> {
+) -> Result<bool, KeytarError> {
   let search_results = ItemSearchOptions::new()
     .class(ItemClass::generic_password())
     .label(service.as_str())
@@ -77,15 +70,15 @@ pub fn find_credentials(
     .load_attributes(true)
     .load_data(true)
     .load_refs(true)
-    .search()
-    .unwrap();
+    .search()?;
 
   for result in search_results {
-    let result_map = result.simplify_dict().unwrap();
-    credentials.push((
-      result_map.get("acct").unwrap().to_string(),
-      result_map.get("v_Data").unwrap().to_string(),
-    ))
+    if let Some(result_map) = result.simplify_dict() {
+      credentials.push((
+        result_map.get("acct").unwrap().to_string(),
+        result_map.get("v_Data").unwrap().to_string(),
+      ))
+    }
   }
   Ok(!credentials.is_empty())
 }

--- a/src/keytar/mac.rs
+++ b/src/keytar/mac.rs
@@ -9,8 +9,8 @@ use security_framework::{
 impl From<security_framework::base::Error> for Error {
   fn from(error: security_framework::base::Error) -> Self {
     Error {
-      code: None,
-      details: Some(error.to_string()),
+      code: error.code(),
+      details: error.message(),
     }
   }
 }

--- a/src/keytar/unix.rs
+++ b/src/keytar/unix.rs
@@ -8,7 +8,7 @@ use super::error::KeytarError;
 impl From<secret_service::Error> for KeytarError {
   fn from(err: secret_service::Error) -> Self {
     KeytarError::Library {
-      service: "secret_service".to_string(),
+      name: "secret_service".to_string(),
       details: format!("{:?}", err),
     }
   }

--- a/src/keytar/unix.rs
+++ b/src/keytar/unix.rs
@@ -1,13 +1,15 @@
 extern crate secret_service;
-use crate::keytar::error::Error;
-use secret_service::{EncryptionType, SecretService};
 use std::collections::HashMap;
 
-impl From<secret_service::Error> for Error {
-  fn from(error: secret_service::Error) -> Self {
-    Error {
-      code: None,
-      details: Some(error.to_string()),
+use secret_service::{EncryptionType, SecretService};
+
+use super::error::KeytarError;
+
+impl From<secret_service::Error> for KeytarError {
+  fn from(err: secret_service::Error) -> Self {
+    KeytarError::Library {
+      service: "secret_service".to_string(),
+      details: format!("{:?}", err),
     }
   }
 }
@@ -16,7 +18,7 @@ pub fn set_password(
   service: &String,
   account: &String,
   password: &mut String,
-) -> Result<bool, Error> {
+) -> Result<bool, KeytarError> {
   let ss = SecretService::new(EncryptionType::Dh)?;
 
   let collection = ss.get_default_collection()?;
@@ -30,38 +32,37 @@ pub fn set_password(
     false,
     "text/plain",
   ) {
-    Ok(item) => Ok(true),
-    Err(err) => Err(Error::from(err)),
+    Ok(_item) => Ok(true),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
-pub fn get_password(service: &String, account: &String) -> Result<String, Error> {
+pub fn get_password(service: &String, account: &String) -> Result<String, KeytarError> {
   let ss = SecretService::new(EncryptionType::Dh)?;
 
   match ss.search_items(vec![("service", service), ("account", account)]) {
     Ok(item) => match item.get(0) {
       Some(it) => {
-        let bytes = it.get_secret().unwrap();
-        return Ok(String::from_utf8(bytes).unwrap());
+        let bytes = it.get_secret()?;
+        return Ok(String::from_utf8(bytes)?);
       }
-      None => Err(Error::from_details(
-        "No items found with the specified attributes",
-      )),
+      None => Err(KeytarError::NotFound),
     },
-    Err(err) => Err(Error::from(err)),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
-pub fn find_password(service: &String) -> Result<String, Error> {
+pub fn find_password(service: &String) -> Result<String, KeytarError> {
   let ss = SecretService::new(EncryptionType::Dh)?;
+
   let collection = ss.get_default_collection()?;
 
   let items = collection.get_all_items()?;
   for item in items {
     let label = item.get_label()?;
     if label.contains(service) {
-      let bytes = item.get_secret().unwrap();
-      let pw = String::from_utf8(bytes).unwrap();
+      let bytes = item.get_secret()?;
+      let pw = String::from_utf8(bytes)?;
       return Ok(pw);
     }
   }
@@ -69,28 +70,27 @@ pub fn find_password(service: &String) -> Result<String, Error> {
   Ok(String::default())
 }
 
-pub fn delete_password(service: &String, account: &String) -> Result<bool, Error> {
+pub fn delete_password(service: &String, account: &String) -> Result<bool, KeytarError> {
   let ss = SecretService::new(EncryptionType::Dh)?;
 
   match ss.search_items(vec![("service", service), ("account", account)]) {
     Ok(item) => match item.get(0) {
       Some(it) => {
-        it.delete().unwrap();
+        it.delete()?;
         return Ok(true);
       }
-      None => Err(Error::from_details(
-        "No items found with the specified attributes",
-      )),
+      None => Err(KeytarError::NotFound),
     },
-    Err(err) => Err(Error::from(err)),
+    Err(err) => Err(KeytarError::from(err)),
   }
 }
 
 pub fn find_credentials(
   service: &String,
   credentials: &mut Vec<(String, String)>,
-) -> Result<bool, Error> {
+) -> Result<bool, KeytarError> {
   let ss = SecretService::new(EncryptionType::Dh)?;
+
   let collection = ss.get_default_collection()?;
 
   let items = collection.get_all_items()?;
@@ -98,8 +98,8 @@ pub fn find_credentials(
     let label = item.get_label()?;
     if label.contains(service) {
       let cred: Vec<&str> = label.split("/").collect();
-      let bytes = item.get_secret().unwrap();
-      let pw = String::from_utf8(bytes).unwrap();
+      let bytes = item.get_secret()?;
+      let pw = String::from_utf8(bytes)?;
       if cred.is_empty() {
         credentials.push((String::default(), pw));
       } else {

--- a/src/keytar/win.rs
+++ b/src/keytar/win.rs
@@ -30,7 +30,7 @@ pub fn set_password(
     unsafe {
       error_code = GetLastError();
     }
-    return Err(KeytarError::OSError(
+    return Err(KeytarError::Os(
       error_code.to_hresult().message().to_string(),
     ));
   }
@@ -59,7 +59,7 @@ pub fn get_password(service: &String, account: &String) -> Result<String, Keytar
       error_code = GetLastError();
     }
 
-    return Err(KeytarError::OSError(
+    return Err(KeytarError::Os(
       error_code.to_hresult().message().to_string(),
     ));
   }
@@ -103,7 +103,7 @@ pub fn delete_password(service: &String, account: &String) -> Result<bool, Keyta
       return Ok(false);
     }
 
-    return Err(KeytarError::OSError(
+    return Err(KeytarError::Os(
       error_code.to_hresult().message().to_string(),
     ));
   }
@@ -137,7 +137,7 @@ pub fn find_password(service: &String) -> Result<String, KeytarError> {
       return Ok(String::default());
     }
 
-    return Err(KeytarError::OSError(
+    return Err(KeytarError::Os(
       error_code.to_hresult().message().to_string(),
     ));
   }
@@ -185,7 +185,7 @@ pub fn find_credentials(
       return Ok(false);
     }
 
-    return Err(KeytarError::OSError(
+    return Err(KeytarError::Os(
       error_code.to_hresult().message().to_string(),
     ));
   }

--- a/src/keytar/win.rs
+++ b/src/keytar/win.rs
@@ -7,7 +7,7 @@ use crate::keytar::error::Error;
 impl From<WIN32_ERROR> for Error {
   fn from(error: WIN32_ERROR) -> Self {
     Error {
-      code: Some(error.0),
+      code: Some(error.0 as i32),
       details: Some(error.to_hresult().message().to_string()),
     }
   }


### PR DESCRIPTION
~~Note: Probably should be tested on a macOS machine to confirm no breaking changes - but, code does cross-compile w/o errors, and core functionality remains the same.~~

**Update:** Thanks @awharn for testing this on macOS for x86_64 and aarch64 :smile:

---

Previously, the core implementation was using an Error struct. This has been changed to an enum and avoids extra boilerplate for error formatting, thanks to the `thiserror` crate.

This PR also adds the test functions for `deletePassword, findCredentials, & findPassword` under the following Yarn scripts:
- `test:delete`
- `test:find`

Tests are still set-up to only run get/set with `yarn test` - CI was updated to run those above scripts in succession.