### PR TITLE
feat: add postinstall script (only runs when added as dep)

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "build": "napi build --platform --release",
     "build:debug": "napi build --platform",
     "prepare": "napi build --platform --release",
+    "postinstall": "node -e \"if(!require('fs').existsSync('.git')) process.exit(1);\" || napi build --platform --release",
     "prepublishOnly": "napi prepublish -t npm",
     "test": "ava",
     "version": "napi version"


### PR DESCRIPTION
The `postinstall` script will check for the presence of a `.git` folder - assuming that the user is pulling down the source, it will short-circuit the OR statement and avoid running the `napi build` command as a result. Otherwise, this will allow `npm` to build the package when pulling it down as a dependency.

I had to add this script because `prepare` does not run when installing `keytar-rs` as a dependency. This will save any headaches when installing `keytar-rs` for development/testing via `npm/yarn`, as it will now build the correct binary when added as a dependency.