### PR TITLE
feat: use `windows-sys` instead of `windows`; remove mutability where possible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ dependencies = [
  "slab",
  "socket2",
  "waker-fn",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -648,7 +648,7 @@ dependencies = [
  "libc",
  "log",
  "wepoll-ffi",
- "windows-sys",
+ "windows-sys 0.42.0",
 ]
 
 [[package]]
@@ -934,7 +934,7 @@ dependencies = [
  "secret-service",
  "security-framework",
  "thiserror",
- "windows",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1005,33 +1005,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
-name = "windows"
-version = "0.43.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04662ed0e3e5630dfa9b26e4cb823b817f1a9addda855d973a9458c236556244"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
 name = "windows-sys"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_aarch64_gnullvm 0.42.0",
+ "windows_aarch64_msvc 0.42.0",
+ "windows_i686_gnu 0.42.0",
+ "windows_i686_msvc 0.42.0",
+ "windows_x86_64_gnu 0.42.0",
+ "windows_x86_64_gnullvm 0.42.0",
+ "windows_x86_64_msvc 0.42.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.0",
+ "windows_aarch64_msvc 0.48.0",
+ "windows_i686_gnu 0.48.0",
+ "windows_i686_msvc 0.48.0",
+ "windows_x86_64_gnu 0.48.0",
+ "windows_x86_64_gnullvm 0.48.0",
+ "windows_x86_64_msvc 0.48.0",
 ]
 
 [[package]]
@@ -1041,10 +1050,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -1053,10 +1074,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
+
+[[package]]
 name = "windows_i686_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -1065,16 +1098,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
 
 [[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
+
+[[package]]
 name = "windows_x86_64_gnullvm"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
 
 [[package]]
 name = "zbus"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,9 @@ thiserror = "1.0.38"
 features = [
   "Win32_Foundation",
   "Win32_Security_Credentials",
+  "Win32_System_Diagnostics_Debug",
+  "Win32_System_Memory",
   "Win32_System_WindowsProgramming",
-  "Win32_System_Diagnostics_Debug"
 ]
 version = "0.48.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ thiserror = "1.0.38"
 features = [
   "Win32_Foundation",
   "Win32_Security_Credentials",
+  "Win32_System_WindowsProgramming",
+  "Win32_System_Diagnostics_Debug"
 ]
 version = "0.48.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,12 +13,12 @@ napi = {version = "2.13.2", default-features = false, features = ["napi4"]}
 napi-derive = "2.13.0"
 thiserror = "1.0.38"
 
-[target.'cfg(target_os = "windows")'.dependencies.windows]
+[target.'cfg(target_os = "windows")'.dependencies.windows-sys]
 features = [
   "Win32_Foundation",
   "Win32_Security_Credentials",
 ]
-version = "0.43.0"
+version = "0.48.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 security-framework = "2.9.1"

--- a/src/keytar/mac.rs
+++ b/src/keytar/mac.rs
@@ -10,7 +10,7 @@ use security_framework::{
 impl From<security_framework::base::Error> for KeytarError {
   fn from(error: security_framework::base::Error) -> Self {
     KeytarError::Library {
-      name: "security_framework".to_string(),
+      name: "security_framework".to_owned(),
       details: format!("{:?}", error),
     }
   }
@@ -38,8 +38,8 @@ pub fn find_password(service: &String) -> Result<Option<String>, KeytarError> {
   let cred_attrs: Vec<&str> = service.split("/").collect();
   if cred_attrs.len() < 2 {
     return Err(KeytarError::InvalidArg {
-      argument: "service".to_string(),
-      details: "Invalid format for service string; must be in format 'SERVICE/ACCOUNT'".to_string(),
+      argument: "service".to_owned(),
+      details: "Invalid format for service string; must be in format 'SERVICE/ACCOUNT'".to_owned(),
     });
   }
 
@@ -75,8 +75,8 @@ pub fn find_credentials(
   for result in search_results {
     if let Some(result_map) = result.simplify_dict() {
       credentials.push((
-        result_map.get("acct").unwrap().to_string(),
-        result_map.get("v_Data").unwrap().to_string(),
+        result_map.get("acct").unwrap().to_owned(),
+        result_map.get("v_Data").unwrap().to_owned(),
       ))
     }
   }

--- a/src/keytar/unix.rs
+++ b/src/keytar/unix.rs
@@ -8,7 +8,7 @@ use super::error::KeytarError;
 impl From<secret_service::Error> for KeytarError {
   fn from(err: secret_service::Error) -> Self {
     KeytarError::Library {
-      name: "secret_service".to_string(),
+      name: "secret_service".to_owned(),
       details: format!("{:?}", err),
     }
   }
@@ -51,7 +51,7 @@ pub fn get_password(service: &String, account: &String) -> Result<Option<String>
     Err(err) => match err {
       secret_service::Error::NoResult => Ok(None),
       _ => Err(KeytarError::from(err)),
-    }
+    },
   }
 }
 
@@ -87,7 +87,7 @@ pub fn delete_password(service: &String, account: &String) -> Result<bool, Keyta
     Err(err) => match err {
       secret_service::Error::NoResult => Ok(false),
       _ => Err(KeytarError::from(err)),
-    }
+    },
   }
 }
 
@@ -109,7 +109,7 @@ pub fn find_credentials(
       if cred.is_empty() {
         credentials.push((String::default(), pw));
       } else {
-        credentials.push((cred[1].to_string(), pw));
+        credentials.push((cred[1].to_owned(), pw));
       }
     }
   }

--- a/src/keytar/win.rs
+++ b/src/keytar/win.rs
@@ -3,7 +3,7 @@ use std::ffi::{c_void, OsStr};
 use std::os::windows::prelude::OsStrExt;
 use std::result::Result;
 use windows_sys::{
-  core::*,
+  core::{PCWSTR, PWSTR},
   Win32::Foundation::*,
   Win32::Security::Credentials::*,
   Win32::System::Diagnostics::Debug::{

--- a/src/keytar/win.rs
+++ b/src/keytar/win.rs
@@ -2,11 +2,51 @@ use super::error::KeytarError;
 use std::ffi::{c_void, OsStr};
 use std::os::windows::prelude::OsStrExt;
 use std::result::Result;
-use windows_sys::{core::*, Win32::Foundation::*, Win32::Security::Credentials::*};
+use windows_sys::{
+  core::*,
+  Win32::Foundation::*,
+  Win32::Security::Credentials::*,
+  Win32::System::Diagnostics::Debug::{
+    FormatMessageW, FORMAT_MESSAGE_ALLOCATE_BUFFER, FORMAT_MESSAGE_FROM_SYSTEM,
+    FORMAT_MESSAGE_IGNORE_INSERTS,
+  },
+  Win32::System::WindowsProgramming::uaw_wcslen,
+};
 
 impl From<WIN32_ERROR> for KeytarError {
   fn from(error: WIN32_ERROR) -> Self {
-    KeytarError::Os(error.to_hresult().message().to_string())
+    KeytarError::Os(win32_error_as_string(error))
+  }
+}
+
+/**
+ * Helper function to convert the last Win32 error into a human-readable error message.
+ * Returns: A String containing the error message.
+ */
+fn win32_error_as_string(error: WIN32_ERROR) -> String {
+  let buffer: PWSTR = std::ptr::null_mut();
+
+  // https://github.com/microsoft/windows-rs/blob/master/crates/libs/core/src/hresult.rs#L96
+  let as_hresult = if error == 0 {
+    0
+  } else {
+    (error & 0x0000_FFFF) | (7 << 16) | 0x8000_0000
+  } as _;
+  unsafe {
+    let size = FormatMessageW(
+      FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+      as_hresult as *const c_void,
+      as_hresult,
+      0,
+      buffer,
+      0,
+      std::ptr::null()
+    );
+
+    String::from_utf16(std::slice::from_raw_parts(
+      buffer,
+      size as usize
+    )).unwrap_or("No error details available.".to_string())
   }
 }
 
@@ -17,13 +57,13 @@ impl From<WIN32_ERROR> for KeytarError {
  * or None otherwise.
  */
 fn encode_utf16(str: &str) -> Option<Vec<u16>> {
-  let mut wide: Vec<u16> = OsStr::new(str).encode_wide().collect();
-  if wide.iter().any(|b| *b == 0) {
+  let mut chars: Vec<u16> = OsStr::new(str).encode_wide().collect();
+  if chars.iter().any(|b| *b == 0u16) {
     return None;
   }
 
-  wide.push(0);
-  return Some(wide)
+  chars.push(0u16);
+  Some(chars)
 }
 
 pub fn set_password(
@@ -31,25 +71,34 @@ pub fn set_password(
   account: &String,
   password: &mut String,
 ) -> Result<bool, KeytarError> {
-
   // Build WinAPI strings and object parameters from arguments
-  let mut target_bytes: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
-    None => return Err(KeytarError::InvalidArg { argument: "service/account".to_string(), details: "Service/account could not be converted to UTF-16.".to_string() }),
-    Some(val) => val
+  let target_bytes: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
+    None => {
+      return Err(KeytarError::InvalidArg {
+        argument: "service/account".to_string(),
+        details: "Service/account could not be converted to UTF-16.".to_string(),
+      })
+    }
+    Some(val) => val,
   };
-  let mut username_bytes: Vec<u16> = match encode_utf16(account.as_str()) {
-    None => return Err(KeytarError::InvalidArg { argument: "username".to_string(), details: "Username could not be converted to UTF-16.".to_string() }),
-    Some(val) => val
+  let username_bytes: Vec<u16> = match encode_utf16(account.as_str()) {
+    None => {
+      return Err(KeytarError::InvalidArg {
+        argument: "username".to_string(),
+        details: "Username could not be converted to UTF-16.".to_string(),
+      })
+    }
+    Some(val) => val,
   };
-  
-  let mut cred = CREDENTIALW {
+
+  let cred = CREDENTIALW {
     Flags: 0,
     Type: CRED_TYPE_GENERIC,
     TargetName: target_bytes.as_ptr() as PWSTR,
     Comment: std::ptr::null_mut(),
     LastWritten: FILETIME {
-        dwLowDateTime: 0,
-        dwHighDateTime: 0,
+      dwLowDateTime: 0,
+      dwHighDateTime: 0,
     },
     Persist: CRED_PERSIST_ENTERPRISE,
     CredentialBlobSize: password.len() as u32,
@@ -79,9 +128,14 @@ pub fn set_password(
 
 pub fn get_password(service: &String, account: &String) -> Result<Option<String>, KeytarError> {
   let mut cred: *mut CREDENTIALW = std::ptr::null_mut::<CREDENTIALW>();
-  let mut target_name: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
-    None => return Err(KeytarError::InvalidArg { argument: "service/account".to_string(), details: "Service/account could not be converted to UTF-16.".to_string() }),
-    Some(val) => val
+  let target_name: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
+    None => {
+      return Err(KeytarError::InvalidArg {
+        argument: "service/account".to_string(),
+        details: "Service/account could not be converted to UTF-16.".to_string(),
+      })
+    }
+    Some(val) => val,
   };
 
   // Attempt to read credential from user's credential set
@@ -109,34 +163,35 @@ pub fn get_password(service: &String, account: &String) -> Result<Option<String>
   }
 
   // Build buffer for credential secret and return as UTF-8 string
-  unsafe {  
-    let bytes = std::slice::from_raw_parts(
-      (*cred).CredentialBlob,
-      (*cred).CredentialBlobSize as usize,
-    );
+  unsafe {
+    let bytes =
+      std::slice::from_raw_parts((*cred).CredentialBlob, (*cred).CredentialBlobSize as usize);
 
     CredFree(cred as *const c_void);
     return match String::from_utf8(bytes.to_vec()) {
       Ok(str) => Ok(Some(str)),
-      Err(err) => Err(KeytarError::Utf8(format!("Failed to convert credential to UTF-8: {}", err).to_string()))
+      Err(err) => Err(KeytarError::Utf8(
+        format!("Failed to convert credential to UTF-8: {}", err).to_string(),
+      )),
     };
   }
 }
 
 pub fn delete_password(service: &String, account: &String) -> Result<bool, KeytarError> {
-  let mut target_name: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
-    None => return Err(KeytarError::InvalidArg { argument: "service/account".to_string(), details: "Service/account could not be converted to UTF-16.".to_string() }),
-    Some(val) => val
+  let target_name: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
+    None => {
+      return Err(KeytarError::InvalidArg {
+        argument: "service/account".to_string(),
+        details: "Service/account could not be converted to UTF-16.".to_string(),
+      })
+    }
+    Some(val) => val,
   };
 
   // Attempt to delete credential from user's credential set
   let delete_result: i32;
   unsafe {
-    delete_result = CredDeleteW(
-      target_name.as_ptr() as PCWSTR,
-      CRED_TYPE_GENERIC,
-      0,
-    );
+    delete_result = CredDeleteW(target_name.as_ptr() as PCWSTR, CRED_TYPE_GENERIC, 0);
   }
 
   if delete_result != TRUE {
@@ -158,9 +213,14 @@ pub fn delete_password(service: &String, account: &String) -> Result<bool, Keyta
 }
 
 pub fn find_password(service: &String) -> Result<Option<String>, KeytarError> {
-  let mut filter: Vec<u16> = match encode_utf16(format!("{}*", service).as_str()) {
-    None => return Err(KeytarError::InvalidArg { argument: "service".to_string(), details: "Service could not be converted to UTF-16.".to_string() }),
-    Some(val) => val  
+  let filter: Vec<u16> = match encode_utf16(format!("{}*", service).as_str()) {
+    None => {
+      return Err(KeytarError::InvalidArg {
+        argument: "service".to_string(),
+        details: "Service could not be converted to UTF-16.".to_string(),
+      })
+    }
+    Some(val) => val,
   };
 
   let mut count: u32 = 0;
@@ -207,9 +267,14 @@ pub fn find_credentials(
   service: &String,
   credentials: &mut Vec<(String, String)>,
 ) -> Result<bool, KeytarError> {
-  let mut filter_bytes: Vec<u16> = match encode_utf16(format!("{}*", service).as_str()) {
-    None => return Err(KeytarError::InvalidArg { argument: "service".to_string(), details: "Service could not be converted to UTF-16.".to_string() }),
-    Some(val) => val  
+  let filter_bytes: Vec<u16> = match encode_utf16(format!("{}*", service).as_str()) {
+    None => {
+      return Err(KeytarError::InvalidArg {
+        argument: "service".to_string(),
+        details: "Service could not be converted to UTF-16.".to_string(),
+      })
+    }
+    Some(val) => val,
   };
   let filter = filter_bytes.as_ptr() as PCWSTR;
 
@@ -260,7 +325,10 @@ pub fn find_credentials(
 
     let username: String;
     unsafe {
-      username = cred.UserName.to_string()?;
+      username = String::from_utf16(std::slice::from_raw_parts(
+        cred.UserName,
+        uaw_wcslen(cred.UserName),
+      ))?;
     }
     credentials.push((username, password));
   }

--- a/src/keytar/win.rs
+++ b/src/keytar/win.rs
@@ -1,7 +1,8 @@
 use super::error::KeytarError;
-use std::ffi::c_void;
+use std::ffi::{c_void, OsStr};
+use std::os::windows::prelude::OsStrExt;
 use std::result::Result;
-use windows::{core::*, Win32::Foundation::*, Win32::Security::Credentials::*};
+use windows_sys::{core::*, Win32::Foundation::*, Win32::Security::Credentials::*};
 
 impl From<WIN32_ERROR> for KeytarError {
   fn from(error: WIN32_ERROR) -> Self {
@@ -9,35 +10,64 @@ impl From<WIN32_ERROR> for KeytarError {
   }
 }
 
+/**
+ * Helper function to encode a string as UTF-16 for usage w/ credential APIs.
+ * Returns:
+ * Some(val) if the string was successfully converted to UTF-16,
+ * or None otherwise.
+ */
+fn encode_utf16(str: &str) -> Option<Vec<u16>> {
+  let mut wide: Vec<u16> = OsStr::new(str).encode_wide().collect();
+  if wide.iter().any(|b| *b == 0) {
+    return None;
+  }
+
+  wide.push(0);
+  return Some(wide)
+}
+
 pub fn set_password(
   service: &String,
   account: &String,
   password: &mut String,
 ) -> Result<bool, KeytarError> {
-  let mut cred = CREDENTIALW {
-    Type: CRED_TYPE_GENERIC,
-    ..Default::default()
-  };
 
   // Build WinAPI strings and object parameters from arguments
-  let mut target_bytes: Vec<u16> = format!("{}/{}", service, account).encode_utf16().collect();
-  target_bytes.push(0);
-  cred.TargetName = PWSTR::from_raw(target_bytes.as_mut_ptr());
-  let mut username_bytes: Vec<u16> = account.encode_utf16().collect();
-  username_bytes.push(0);
-  cred.UserName = PWSTR::from_raw(username_bytes.as_mut_ptr());
-  cred.CredentialBlobSize = password.len() as u32;
-  cred.CredentialBlob = password.as_mut_ptr();
-  cred.Persist = CRED_PERSIST_ENTERPRISE;
+  let mut target_bytes: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
+    None => return Err(KeytarError::InvalidArg { argument: "service/account".to_string(), details: "Service/account could not be converted to UTF-16.".to_string() }),
+    Some(val) => val
+  };
+  let mut username_bytes: Vec<u16> = match encode_utf16(account.as_str()) {
+    None => return Err(KeytarError::InvalidArg { argument: "username".to_string(), details: "Username could not be converted to UTF-16.".to_string() }),
+    Some(val) => val
+  };
+  
+  let mut cred = CREDENTIALW {
+    Flags: 0,
+    Type: CRED_TYPE_GENERIC,
+    TargetName: target_bytes.as_ptr() as PWSTR,
+    Comment: std::ptr::null_mut(),
+    LastWritten: FILETIME {
+        dwLowDateTime: 0,
+        dwHighDateTime: 0,
+    },
+    Persist: CRED_PERSIST_ENTERPRISE,
+    CredentialBlobSize: password.len() as u32,
+    CredentialBlob: password.as_ptr() as *mut u8,
+    AttributeCount: 0,
+    Attributes: std::ptr::null_mut(),
+    TargetAlias: std::ptr::null_mut(),
+    UserName: username_bytes.as_ptr() as PWSTR,
+  };
 
   // Save credential to user's credential set
-  let write_result: bool;
+  let write_result: i32;
   unsafe {
-    write_result = bool::from(CredWriteW(&cred, 0));
+    write_result = CredWriteW(&cred, 0);
   }
 
   let error_code: WIN32_ERROR;
-  if !write_result {
+  if write_result != TRUE {
     unsafe {
       error_code = GetLastError();
     }
@@ -49,21 +79,23 @@ pub fn set_password(
 
 pub fn get_password(service: &String, account: &String) -> Result<Option<String>, KeytarError> {
   let mut cred: *mut CREDENTIALW = std::ptr::null_mut::<CREDENTIALW>();
-  let mut target_name: Vec<u16> = format!("{}/{}", service, account).encode_utf16().collect();
-  target_name.push(0);
+  let mut target_name: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
+    None => return Err(KeytarError::InvalidArg { argument: "service/account".to_string(), details: "Service/account could not be converted to UTF-16.".to_string() }),
+    Some(val) => val
+  };
 
   // Attempt to read credential from user's credential set
-  let read_result: bool;
+  let read_result: i32;
   unsafe {
-    read_result = bool::from(CredReadW(
-      PCWSTR::from_raw(target_name.as_mut_ptr()),
-      CRED_TYPE_GENERIC.0,
+    read_result = CredReadW(
+      target_name.as_ptr() as PCWSTR,
+      CRED_TYPE_GENERIC,
       0,
       &mut cred,
-    ));
+    );
   }
 
-  if !read_result {
+  if read_result != TRUE {
     let error_code: WIN32_ERROR;
     unsafe {
       error_code = GetLastError();
@@ -77,36 +109,37 @@ pub fn get_password(service: &String, account: &String) -> Result<Option<String>
   }
 
   // Build buffer for credential secret and return as UTF-8 string
-  let mut pw_bytes: Vec<u8> = Vec::new();
-  unsafe {
-    let pw_len = (*cred).CredentialBlobSize as usize;
-    pw_bytes.reserve(pw_len);
-
-    let pw_str = String::from(std::str::from_utf8(std::slice::from_raw_parts(
+  unsafe {  
+    let bytes = std::slice::from_raw_parts(
       (*cred).CredentialBlob,
-      pw_len,
-    ))?);
+      (*cred).CredentialBlobSize as usize,
+    );
 
     CredFree(cred as *const c_void);
-    Ok(Some(pw_str))
+    return match String::from_utf8(bytes.to_vec()) {
+      Ok(str) => Ok(Some(str)),
+      Err(err) => Err(KeytarError::Utf8(format!("Failed to convert credential to UTF-8: {}", err).to_string()))
+    };
   }
 }
 
 pub fn delete_password(service: &String, account: &String) -> Result<bool, KeytarError> {
-  let mut target_name: Vec<u16> = format!("{}/{}", service, account).encode_utf16().collect();
-  target_name.push(0);
+  let mut target_name: Vec<u16> = match encode_utf16(format!("{}/{}", service, account).as_str()) {
+    None => return Err(KeytarError::InvalidArg { argument: "service/account".to_string(), details: "Service/account could not be converted to UTF-16.".to_string() }),
+    Some(val) => val
+  };
 
   // Attempt to delete credential from user's credential set
-  let delete_result: bool;
+  let delete_result: i32;
   unsafe {
-    delete_result = bool::from(CredDeleteW(
-      PCWSTR::from_raw(target_name.as_mut_ptr()),
-      CRED_TYPE_GENERIC.0,
+    delete_result = CredDeleteW(
+      target_name.as_ptr() as PCWSTR,
+      CRED_TYPE_GENERIC,
       0,
-    ));
+    );
   }
 
-  if !delete_result {
+  if delete_result != TRUE {
     let error_code: WIN32_ERROR;
     unsafe {
       error_code = GetLastError();
@@ -125,24 +158,26 @@ pub fn delete_password(service: &String, account: &String) -> Result<bool, Keyta
 }
 
 pub fn find_password(service: &String) -> Result<Option<String>, KeytarError> {
-  let mut filter: Vec<u16> = format!("{}*", service).encode_utf16().collect();
-  filter.push(0);
+  let mut filter: Vec<u16> = match encode_utf16(format!("{}*", service).as_str()) {
+    None => return Err(KeytarError::InvalidArg { argument: "service".to_string(), details: "Service could not be converted to UTF-16.".to_string() }),
+    Some(val) => val  
+  };
 
   let mut count: u32 = 0;
   let mut creds: *mut *mut CREDENTIALW = std::ptr::null_mut::<*mut CREDENTIALW>();
 
   // Attempt to find matching credential from user's credential set
-  let find_result: bool;
+  let find_result: i32;
   unsafe {
-    find_result = bool::from(CredEnumerateW(
-      PCWSTR::from_raw(filter.as_mut_ptr()),
-      CRED_ENUMERATE_FLAGS(0),
+    find_result = CredEnumerateW(
+      filter.as_ptr() as PCWSTR,
+      0u32,
       &mut count,
       &mut creds as *mut *mut *mut CREDENTIALW,
-    ));
+    );
   }
 
-  if !find_result {
+  if find_result != TRUE {
     let error_code: WIN32_ERROR;
     unsafe {
       error_code = GetLastError();
@@ -172,25 +207,27 @@ pub fn find_credentials(
   service: &String,
   credentials: &mut Vec<(String, String)>,
 ) -> Result<bool, KeytarError> {
-  let mut filter_bytes = format!("{}*", service).encode_utf16().collect::<Vec<u16>>();
-  filter_bytes.push(0);
-  let filter = PCWSTR::from_raw(filter_bytes.as_mut_ptr());
+  let mut filter_bytes: Vec<u16> = match encode_utf16(format!("{}*", service).as_str()) {
+    None => return Err(KeytarError::InvalidArg { argument: "service".to_string(), details: "Service could not be converted to UTF-16.".to_string() }),
+    Some(val) => val  
+  };
+  let filter = filter_bytes.as_ptr() as PCWSTR;
 
   let mut count: u32 = 0;
   let mut creds: *mut *mut CREDENTIALW = std::ptr::null_mut::<*mut CREDENTIALW>();
 
   // Attempt to fetch user's credential set
-  let find_result: bool;
+  let find_result: i32;
   unsafe {
-    find_result = bool::from(CredEnumerateW(
+    find_result = CredEnumerateW(
       filter,
-      CRED_ENUMERATE_FLAGS(0),
+      0u32,
       &mut count,
       &mut creds as *mut *mut *mut CREDENTIALW,
-    ));
+    );
   }
 
-  if !find_result {
+  if find_result != TRUE {
     let error_code: WIN32_ERROR;
     unsafe {
       error_code = GetLastError();


### PR DESCRIPTION
This should shrink the size of the binaries by a few KB. Not a drastic reduction in size, but I think its best to take the most barebones approach possible if we are aiming to shrink the size of the platform-specific binaries.

Also added helper functions:
- `encode_utf16` to minimize code duplication
- `win32_error_to_string` to convert `WIN32_ERROR`s into a `String`, since `windows-sys` does not have the same helper functions provided with the `windows` crate