### PR TITLE
fix: update `findCredentials` to support `libsecret < 0.19`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -643,6 +643,7 @@ dependencies = [
  "gio",
  "glib",
  "libsecret",
+ "libsecret-sys",
  "napi",
  "napi-build",
  "napi-derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,8 @@ security-framework = "2.9.1"
 [target.'cfg(any(target_os = "freebsd", target_os = "linux"))'.dependencies]
 glib = "0.17.10"
 gio = "0.17.10"
-libsecret = { version = "0.3.0", features = ["v0_19"] }
+libsecret = "0.3.0"
+libsecret-sys = "0.3.0"
 
 [build-dependencies]
 napi-build = "2.0.1"


### PR DESCRIPTION
This PR uses a different approach to the logic for `findCredentials` so we are not using the `v0_19` feature for `libsecret-rs` (which requires libsecret v0.19 or higher)